### PR TITLE
fix: default empty for service channel parameters.

### DIFF
--- a/internal/provider/notification_rule_resource.go
+++ b/internal/provider/notification_rule_resource.go
@@ -545,12 +545,15 @@ var notificationAction = schema.NestedAttributeObject{
 			Attributes: map[string]schema.Attribute{
 				"store_id": schema.StringAttribute{
 					Optional: true,
+					Computed: true,
 					Description: `A 4-digit number that identifies the store the asset is in.
     								If this is not set, it will be derived from the "service_channel_store_id"
     								label in Studio.`,
+					Default: stringdefault.StaticString(""),
 				},
 				"asset_tag_id": schema.StringAttribute{
 					Optional: true,
+					Computed: true,
 					Description: ` tag that is set on the asset in ServiceChannel. Will be used to find the 
 									asset, and link it to work orders. 
 									When specified, the trade of the asset will be used for the work order instead 
@@ -558,19 +561,24 @@ var notificationAction = schema.NestedAttributeObject{
 									based on this tag, the provided trade will be used instead to derive fields 
 									dependent on the trade. If this is not set, it will be derived from the 
 									"service_channel_asset_tag_id" label in Studio.`,
+					Default: stringdefault.StaticString(""),
 				},
 				"trade": schema.StringAttribute{
 					Optional: true,
+					Computed: true,
 					Description: `The trade to use if the asset tag id is either not specified or no matching
 									asset could be found. If this is not set, it will be derived from the 
 									"service_channel_trade" label in Studio.
 									Examples of a trade could be "REFRIGERATION" or "HOT FOOD".`,
+					Default: stringdefault.StaticString(""),
 				},
 				"description": schema.StringAttribute{
 					Optional: true,
+					Computed: true,
 					Description: `The description that will appear on the work order. If this is not set, 
 									it will be derived from the "service_channel_work_order_description"
 									label in Studio.`,
+					Default: stringdefault.StaticString(""),
 				},
 			},
 		},

--- a/internal/provider/notification_rule_resource_test.go
+++ b/internal/provider/notification_rule_resource_test.go
@@ -260,7 +260,6 @@ func TestAccNotificationRuleResource(t *testing.T) {
 					resource.TestCheckResourceAttr("dt_notification_rule.test", "escalation_levels.3.escalate_after", "3600s"),
 					resource.TestCheckResourceAttr("dt_notification_rule.test", "escalation_levels.3.actions.#", "1"),
 					resource.TestCheckResourceAttr("dt_notification_rule.test", "escalation_levels.3.actions.0.type", "SERVICE_CHANNEL"),
-					resource.TestCheckResourceAttr("dt_notification_rule.test", "escalation_levels.3.actions.0.service_channel_config.asset_tag_id", "asset-tag-id"),
 					resource.TestCheckResourceAttr("dt_notification_rule.test", "escalation_levels.3.actions.0.service_channel_config.description", "Temperature $celsius is over the limit"),
 					resource.TestCheckResourceAttr("dt_notification_rule.test", "escalation_levels.3.actions.0.service_channel_config.store_id", "store-id"),
 					resource.TestCheckResourceAttr("dt_notification_rule.test", "escalation_levels.3.actions.0.service_channel_config.trade", "REFRIGERATION"),

--- a/testdata/notification_rule/all_escalations.tf
+++ b/testdata/notification_rule/all_escalations.tf
@@ -83,10 +83,9 @@ resource "dt_notification_rule" "test" {
       actions = [{
         type = "SERVICE_CHANNEL"
         service_channel_config = {
-          asset_tag_id = "asset-tag-id"
-          description  = "Temperature $celsius is over the limit"
-          store_id     = "store-id"
-          trade        = "REFRIGERATION"
+          description = "Temperature $celsius is over the limit"
+          store_id    = "store-id"
+          trade       = "REFRIGERATION"
         }
       }]
     },


### PR DESCRIPTION
The API will return empty string for null values, causing a state inconsisency. Use empty string as default values.