### PR TITLE
feat: project label support

### DIFF
--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -38,6 +38,7 @@ output "project" {
 - `display_name` (String) The display name of the project.
 - `id` (String) The resource ID of the project.
 - `inventory` (Boolean) Whether the project is an inventory project.
+- `labels` (Map of String) A map of labels assigned to the project.
 - `location` (Object) (see [below for nested schema](#nestedatt--location))
 - `organization` (String) The reource name of the organization that the project belongs to. on the form `organizations/{organization_id}`.
 - `organization_display_name` (String) The display name of the organization that the project belongs to.

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -36,6 +36,10 @@ resource "dt_project" "my_project" {
 - `location` (Attributes) The location of the project. (see [below for nested schema](#nestedatt--location))
 - `organization` (String) The reource name of the organization that the project belongs to. on the form `organizations/{organization_id}`.
 
+### Optional
+
+- `labels` (Map of String) A map of labels to assign to the project.
+
 ### Read-Only
 
 - `cloud_connector_count` (Number) The number of cloud connectors in the project.

--- a/internal/provider/project_data_source.go
+++ b/internal/provider/project_data_source.go
@@ -78,6 +78,11 @@ func (d *projectDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 					"time_location": types.StringType,
 				},
 			},
+			"labels": schema.MapAttribute{
+				Computed:    true,
+				ElementType: types.StringType,
+				Description: "A map of labels assigned to the project.",
+			},
 		},
 	}
 }
@@ -93,6 +98,7 @@ type projectDataSourceModel struct {
 	SensorCount             types.Int32                     `tfsdk:"sensor_count"`
 	CloudConnectorCount     types.Int32                     `tfsdk:"cloud_connector_count"`
 	Location                *projectLocationDataSourceModel `tfsdk:"location"`
+	Labels                  types.Map                       `tfsdk:"labels"`
 }
 
 type projectLocationDataSourceModel struct {

--- a/internal/provider/project_resource_test.go
+++ b/internal/provider/project_resource_test.go
@@ -44,6 +44,7 @@ func TestAccSafeProjectResource(t *testing.T) {
 					resource.TestCheckResourceAttr("dt_project.test", "location.longitude", "10.910202"),
 					resource.TestCheckResourceAttr("dt_project.test", "location.time_location", "Europe/Oslo"),
 					resource.TestCheckResourceAttr("dt_project.test", "inventory", "false"),
+					resource.TestCheckResourceAttr("dt_project.test", "labels.%", "0"),
 				),
 			},
 			{
@@ -65,6 +66,7 @@ func TestAccSafeProjectResource(t *testing.T) {
 					resource.TestCheckResourceAttr("dt_project.test", "location.longitude", "10.63904"),
 					resource.TestCheckResourceAttr("dt_project.test", "location.time_location", "Europe/Oslo"),
 					resource.TestCheckResourceAttr("dt_project.test", "inventory", "false"),
+					resource.TestCheckResourceAttr("dt_project.test", "labels.%", "0"),
 				),
 			},
 		},
@@ -78,6 +80,65 @@ func TestAccSafeProjectResource(t *testing.T) {
 					resource.TestCheckResourceAttr("dt_project.test", "display_name", "Empty Location Project"),
 					resource.TestCheckResourceAttr("dt_project.test", "location.time_location", "UTC"),
 					resource.TestCheckResourceAttr("dt_project.test", "inventory", "false"),
+					resource.TestCheckResourceAttr("dt_project.test", "labels.%", "0"),
+				),
+			},
+		},
+	})
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + `
+resource "dt_project" "test_labels" {
+    display_name = "Project with labels"
+    organization = "organizations/cvinmt9aq9sc738g6eog"
+    location = {
+        time_location = "Europe/Oslo"
+    }
+    labels = {
+        "foo" = "bar"
+    }
+}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("dt_project.test_labels", "display_name", "Project with labels"),
+					resource.TestCheckResourceAttr("dt_project.test_labels", "labels.%", "1"),
+					resource.TestCheckResourceAttr("dt_project.test_labels", "labels.foo", "bar"),
+				),
+			},
+			{
+				Config: providerConfig + `
+resource "dt_project" "test_labels" {
+    display_name = "Project with labels"
+    organization = "organizations/cvinmt9aq9sc738g6eog"
+    location = {
+        time_location = "Europe/Oslo"
+    }
+    labels = {
+        "foo" = "baz"
+        "new" = "label"
+    }
+}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("dt_project.test_labels", "display_name", "Project with labels"),
+					resource.TestCheckResourceAttr("dt_project.test_labels", "labels.%", "2"),
+					resource.TestCheckResourceAttr("dt_project.test_labels", "labels.foo", "baz"),
+					resource.TestCheckResourceAttr("dt_project.test_labels", "labels.new", "label"),
+				),
+			},
+			{
+				Config: providerConfig + `
+resource "dt_project" "test_labels" {
+    display_name = "Project with labels"
+    organization = "organizations/cvinmt9aq9sc738g6eog"
+    location = {
+        time_location = "Europe/Oslo"
+    }
+    labels = {}
+}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("dt_project.test_labels", "display_name", "Project with labels"),
+					resource.TestCheckResourceAttr("dt_project.test_labels", "labels.%", "0"),
 				),
 			},
 		},


### PR DESCRIPTION
Add support for updating project labels.

This is done by using the project batch update endpoint to set the labels after project creation and on update.